### PR TITLE
Migrate to official pycqa/flake8 hooks repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,30 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
     -   id: trailing-whitespace
         exclude: ^day13/input.txt$
     -   id: end-of-file-fixer
     -   id: check-yaml
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.1
+    hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v1.4.3
     hooks:
     -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.3.4
+    rev: v1.3.5
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus, '--application-directories=.:support']
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.10.1
+    rev: v1.11.1
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.641
+    rev: v0.660
     hooks:
     -   id: mypy


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos